### PR TITLE
Set permissions on config and userdata so that the installer can continue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,14 @@ ENV APACHE_RUN_USER www-data
 ENV APACHE_RUN_GROUP www-data
 ENV APACHE_LOG_DIR /var/log/apache2
 
+ENV CONF_PATH /var/www/html/conf
+ENV USERDATA_PATH /var/www/html/userdata
+ENV DOWNLOADS_PATH /var/www/html/download
+
+USER $APACHE_RUN_USER
+RUN mkdir -p ${CONF_PATH} ${USERDATA_PATH} ${DOWNLOADS_PATH}
+USER root
+
 VOLUME /var/www/html/conf
 VOLUME /var/www/html/userdata
 
@@ -73,5 +81,3 @@ RUN chmod +x /usr/local/bin/entry.sh
 ENTRYPOINT ["sh", "/usr/local/bin/entry.sh"]
 
 CMD ["apachectl", "-e", "info", "-D", "FOREGROUND"]
-
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,14 @@ services:
     image: lobaro/xentral-docker:latest
     restart: always
     volumes:
-      - /var/data/xentral/userdata:/var/www/html/userdata
-      - /var/data/xentral/conf:/var/www/html/conf
+      - xentral_userdata:/var/www/html/userdata
+      - xentral_conf:/var/www/html/conf
       # Allows do run the update faster after recreating the container
-      - /var/data/xentral/download:/var/www/html/download
+      - xentral_download:/var/www/html/download
+volumes:
+  xentral_userdata:
+    driver: local
+  xentral_conf:
+    driver: local
+  xentral_download:
+    driver: local


### PR DESCRIPTION
One of the checks that the Xentral installer performs is, if it can write in the `config` and `userdata` folders.

Though the documentation says that the given permissions are enough, the installer actually hides the `continue` button unless the apache user (www-data) has write permissions on the above mentioned folders.

This PR fixes the issue in 2 steps:
1. Changes on the `Dockerfile` so that those folders are created by the apache user.
    Starting a regular container via `docker run ...` assigns a generic volume to those folders with write permissions for www-data
2. Changes on the `docker-compose.yml` to use named volumes instead of absolute paths.
    This solves a problem on mac, where the absolute volumes are (generally) paths from the virtual machine used in Docker for mac, which are all owned by root
  
